### PR TITLE
Add output format option for status and diff commands

### DIFF
--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -1,5 +1,22 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
+use serde_json;
+
+/// Defines the possible output formats for the diff command.
+#[derive(ValueEnum, Clone, Debug)]
+pub enum OutputFormat {
+    Text, // Default format
+    Json,
+}
+
+impl std::fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OutputFormat::Text => write!(f, "text"),
+            OutputFormat::Json => write!(f, "json"),
+        }
+    }
+}
 
 /// The command to show the difference between snapshots or the current state
 #[derive(Parser, Debug)]
@@ -13,6 +30,10 @@ pub struct Diff {
     /// Path to the directory the snapshots belong to
     #[arg(long, default_value = ".")]
     path: PathBuf,
+
+    /// Output format
+    #[arg(long, default_value_t = OutputFormat::Text)]
+    format: OutputFormat,
 }
 
 use crate::{core, database, models, utils};
@@ -52,34 +73,42 @@ impl Diff {
             }
         };
 
-        println!("Comparing {} with {}", name1, name2);
-
         let diff = core::diff::diff_snapshots(&files1, &files2)?;
 
-        if diff.is_empty() {
-            println!("No changes detected.");
-            return Ok(());
-        }
-
-        println!("Changes detected:");
-        if !diff.added.is_empty() {
-            println!("\nAdded files:");
-            for file in diff.added {
-                println!("  + {}", file);
+        match self.format {
+            OutputFormat::Json => {
+                let json_output = serde_json::to_string_pretty(&diff)?;
+                println!("{}", json_output);
             }
-        }
+            OutputFormat::Text => {
+                println!("Comparing {} with {}", name1, name2);
 
-        if !diff.removed.is_empty() {
-            println!("\nRemoved files:");
-            for file in diff.removed {
-                println!("  - {}", file);
-            }
-        }
+                if diff.is_empty() {
+                    println!("No changes detected.");
+                    return Ok(());
+                }
 
-        if !diff.modified.is_empty() {
-            println!("\nModified files:");
-            for file in diff.modified {
-                println!("  * {}", file);
+                println!("Changes detected:");
+                if !diff.added.is_empty() {
+                    println!("\nAdded files:");
+                    for file in diff.added {
+                        println!("  + {}", file);
+                    }
+                }
+
+                if !diff.removed.is_empty() {
+                    println!("\nRemoved files:");
+                    for file in diff.removed {
+                        println!("  - {}", file);
+                    }
+                }
+
+                if !diff.modified.is_empty() {
+                    println!("\nModified files:");
+                    for file in diff.modified {
+                        println!("  * {}", file);
+                    }
+                }
             }
         }
 

--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -138,7 +138,11 @@ impl Diff {
                 };
 
                 let snapshot_id = snapshot_id_result?.ok_or_else(|| {
-                    format!("Could not find a snapshot for revision '{}'", r_str)
+                    if r_str.eq_ignore_ascii_case("HEAD~1") {
+                        "Not enough snapshots to compare. Only one snapshot exists.".to_string()
+                    } else {
+                        format!("Could not find a snapshot for revision '{}'", r_str)
+                    }
                 })?;
 
                 let files = database::get_files_for_snapshot(conn, snapshot_id)?;

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -1,8 +1,25 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
+use serde_json;
 
 use crate::{database, utils};
-use crate::utils::file_lister; // Import the new file_lister module
+use crate::utils::file_lister;
+
+/// Defines the possible output formats for the status command.
+#[derive(ValueEnum, Clone, Debug)]
+pub enum OutputFormat {
+    Text, // Default format
+    Json,
+}
+
+impl std::fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OutputFormat::Text => write!(f, "text"),
+            OutputFormat::Json => write!(f, "json"),
+        }
+    }
+}
 
 /// The command to show the difference between the current directory state and the last snapshot
 #[derive(Parser, Debug)]
@@ -10,48 +27,60 @@ pub struct Status {
     /// Path to the directory to diff
     #[arg(default_value = ".")]
     path: PathBuf,
+
+    /// Output format
+    #[arg(long, default_value_t = OutputFormat::Text)]
+    format: OutputFormat,
 }
 
 impl Status {
     /// Execute the status command
     pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
         let root = std::fs::canonicalize(&self.path)?;
-        println!("Computing status for directory: {}", root.display());
+        
+        let db_path = utils::get_chronicle_db_path()?;
+        let mut conn = database::open(&db_path)?;
 
         // Get current files metadata
         let current_files = file_lister::list_files_with_metadata(&root)?;
 
-        // Open the database
-        let db_path = utils::get_chronicle_db_path()?;
-        let mut conn = database::open(&db_path)?;
-
         // Compute the diff against the last snapshot
         let diff = database::compute_diff(&mut conn, &root.to_string_lossy(), &current_files)?;
 
-        if diff.is_empty() {
-            println!("No changes detected since last snapshot.");
-            return Ok(())
-        }
-
-        println!("Changes detected:");
-        if !diff.added.is_empty() {
-            println!("\nAdded files:");
-            for file in diff.added {
-                println!("  + {}", file);
+        match self.format {
+            OutputFormat::Json => {
+                let json_output = serde_json::to_string_pretty(&diff)?;
+                println!("{}", json_output);
             }
-        }
+            OutputFormat::Text => {
+                println!("Computing status for directory: {}", root.display());
 
-        if !diff.removed.is_empty() {
-            println!("\nRemoved files:");
-            for file in diff.removed {
-                println!("  - {}", file);
-            }
-        }
+                if diff.is_empty() {
+                    println!("No changes detected since last snapshot.");
+                    return Ok(())
+                }
 
-        if !diff.modified.is_empty() {
-            println!("\nModified files:");
-            for file in diff.modified {
-                println!("  * {}", file);
+                println!("Changes detected:");
+                if !diff.added.is_empty() {
+                    println!("\nAdded files:");
+                    for file in diff.added {
+                        println!("  + {}", file);
+                    }
+                }
+
+                if !diff.removed.is_empty() {
+                    println!("\nRemoved files:");
+                    for file in diff.removed {
+                        println!("  - {}", file);
+                    }
+                }
+
+                if !diff.modified.is_empty() {
+                    println!("\nModified files:");
+                    for file in diff.modified {
+                        println!("  * {}", file);
+                    }
+                }
             }
         }
 

--- a/src/database/query.rs
+++ b/src/database/query.rs
@@ -23,10 +23,7 @@ use std::time::UNIX_EPOCH;
 
 use crate::models::{FileMetadata, SnapshotMetadata};
 
-pub fn get_files_for_snapshot(
-    conn: &Connection,
-    snapshot_id: i64,
-) -> Result<Vec<FileMetadata>> {
+pub fn get_files_for_snapshot(conn: &Connection, snapshot_id: i64) -> Result<Vec<FileMetadata>> {
     let mut stmt = conn.prepare(
         "SELECT
             path,
@@ -60,17 +57,13 @@ impl TryFrom<&Row<'_>> for FileMetadata {
         Ok(FileMetadata {
             path: PathBuf::from(row.get::<_, String>(0)?),
             bytes: row.get::<_, i64>(1)? as u64,
-            modified_at: modified_at
-                .map(|t| UNIX_EPOCH + std::time::Duration::from_secs(t as u64)),
-            created_at: created_at
-                .map(|t| UNIX_EPOCH + std::time::Duration::from_secs(t as u64)),
-            accessed_at: accessed_at
-                .map(|t| UNIX_EPOCH + std::time::Duration::from_secs(t as u64)),
+            modified_at: modified_at.map(|t| UNIX_EPOCH + std::time::Duration::from_secs(t as u64)),
+            created_at: created_at.map(|t| UNIX_EPOCH + std::time::Duration::from_secs(t as u64)),
+            accessed_at: accessed_at.map(|t| UNIX_EPOCH + std::time::Duration::from_secs(t as u64)),
             content_hash: row.get(5)?,
         })
     }
 }
-
 
 pub fn get_latest_snapshot_id(conn: &Connection, root: &str) -> Result<Option<i64>> {
     conn.query_row(
@@ -81,10 +74,7 @@ pub fn get_latest_snapshot_id(conn: &Connection, root: &str) -> Result<Option<i6
     .optional()
 }
 
-pub fn list_snapshots_for_root(
-    conn: &Connection,
-    root: &str,
-) -> Result<Vec<SnapshotMetadata>> {
+pub fn list_snapshots_for_root(conn: &Connection, root: &str) -> Result<Vec<SnapshotMetadata>> {
     let mut stmt = conn.prepare(
         "SELECT
             s.id,

--- a/src/models/diff.rs
+++ b/src/models/diff.rs
@@ -1,3 +1,4 @@
+#[derive(serde::Serialize)]
 pub struct Diff {
     pub added: Vec<String>,
     pub removed: Vec<String>,


### PR DESCRIPTION
Introduce an `OutputFormat` enum to allow users to select between text and JSON output formats for the `status` and `diff` commands. Update the argument parsing and output handling logic accordingly. Refactor code for improved formatting and clarity.