### PR TITLE
Add global database path argument

### DIFF
--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -36,14 +36,14 @@ pub struct Diff {
     format: OutputFormat,
 }
 
-use crate::{core, database, models, utils};
+use crate::{core, database, models, utils, cli};
 use std::path::Path;
 
 impl Diff {
     /// Execute the diff command
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, cli: &cli::Args) -> Result<(), Box<dyn std::error::Error>> {
         let root = std::fs::canonicalize(&self.path)?;
-        let db_path = utils::get_chronicle_db_path()?;
+        let db_path = utils::get_chronicle_db_path(cli.db.as_ref())?;
         let conn = database::open(&db_path)?;
 
         // Determine which revisions to compare based on the number of arguments

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use chrono::{Local, DateTime};
 use serde_json;
 
-use crate::{database, models, output_formatter, utils};
+use crate::{database, models, output_formatter, utils, cli};
 use crate::output_formatter::OutputFormatter;
 
 /// Defines the possible output formats for the list command.
@@ -36,10 +36,10 @@ pub struct List {
 
 impl List {
     /// Execute the command to list all snapshots for a given directory
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, cli: &cli::Args) -> Result<(), Box<dyn std::error::Error>> {
         let root = std::fs::canonicalize(&self.path)?;
 
-        let db_path = utils::get_chronicle_db_path()?;
+        let db_path = utils::get_chronicle_db_path(cli.db.as_ref())?;
         let conn = database::open(&db_path)?;
 
         let snapshots = database::list_snapshots_for_root(&conn, &root.to_string_lossy())?;

--- a/src/cli/commands/snapshot.rs
+++ b/src/cli/commands/snapshot.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use clap::Parser;
 
-use crate::core;
+use crate::{core, cli};
 
 /// The command to scan a directory and record a snapshot
 #[derive(Parser, Debug)]
@@ -13,7 +13,7 @@ pub struct Snapshot {
 
 impl Snapshot {
     /// Execute the command to scan a directory and record a snapshot
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
-        core::snapshot::take_snapshot(&self.path)
+    pub fn execute(&self, cli: &cli::Args) -> Result<(), Box<dyn std::error::Error>> {
+        core::snapshot::take_snapshot(&self.path, cli.db.as_ref())
     }
 }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -2,7 +2,7 @@ use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 use serde_json;
 
-use crate::{database, utils};
+use crate::{database, utils, cli};
 use crate::utils::file_lister;
 
 /// Defines the possible output formats for the status command.
@@ -35,10 +35,10 @@ pub struct Status {
 
 impl Status {
     /// Execute the status command
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, cli: &cli::Args) -> Result<(), Box<dyn std::error::Error>> {
         let root = std::fs::canonicalize(&self.path)?;
         
-        let db_path = utils::get_chronicle_db_path()?;
+        let db_path = utils::get_chronicle_db_path(cli.db.as_ref())?;
         let mut conn = database::open(&db_path)?;
 
         // Get current files metadata

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use crate::core;
+use crate::{core, cli};
 
 /// The command to synchronize Git history into chronicle
 #[derive(Parser, Debug)]
@@ -13,8 +13,8 @@ pub struct Sync {
 
 impl Sync {
     /// Execute the command to synchronize Git history
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, cli: &cli::Args) -> Result<(), Box<dyn std::error::Error>> {
         println!("Synchronizing Git history from: {}", self.path.display());
-        core::git_sync::sync_history(&self.path)
+        core::git_sync::sync_history(&self.path, cli.db.as_ref())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 pub mod commands;
 
@@ -7,6 +8,10 @@ pub mod commands;
 pub struct Args {
     #[command(subcommand)]
     pub command: Commands,
+
+    /// Path to the chronicle database file
+    #[arg(long, global = true)]
+    pub db: Option<PathBuf>,
 }
 
 /// The subcommands of the command-line-interface

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -23,8 +23,8 @@ pub fn initialize_schema(conn: &mut Connection) -> Result<()> {
     Ok(())
 }
 
-pub fn store_snapshot(snapshot: models::Snapshot) -> Result<(), Box<dyn std::error::Error>> {
-    let db_path = utils::get_chronicle_db_path()?;
+pub fn store_snapshot(snapshot: models::Snapshot, db_path_override: Option<&std::path::PathBuf>) -> Result<(), Box<dyn std::error::Error>> {
+    let db_path = utils::get_chronicle_db_path(db_path_override)?;
     let mut conn = open(&db_path)?;
 
     // Compute Diff

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,10 @@ fn main() {
 /// Run the command-line-interface
 fn run(cli: &cli::Args) -> Result<(), Box<dyn std::error::Error>> {
     match &cli.command {
-        cli::Commands::Snapshot(cmd) => cmd.execute(),
-        cli::Commands::List(cmd) => cmd.execute(),
-        cli::Commands::Status(cmd) => cmd.execute(),
-        cli::Commands::Diff(cmd) => cmd.execute(),
-        cli::Commands::Sync(cmd) => cmd.execute(),
+        cli::Commands::Snapshot(cmd) => cmd.execute(cli),
+        cli::Commands::List(cmd) => cmd.execute(cli),
+        cli::Commands::Status(cmd) => cmd.execute(cli),
+        cli::Commands::Diff(cmd) => cmd.execute(cli),
+        cli::Commands::Sync(cmd) => cmd.execute(cli),
     }
 }

--- a/src/utils/data_dir.rs
+++ b/src/utils/data_dir.rs
@@ -43,7 +43,13 @@ pub fn get_chronicle_dir() -> std::io::Result<PathBuf> {
     Ok(chronicle_dir)
 }
 
-pub fn get_chronicle_db_path() -> std::io::Result<PathBuf> {
+pub fn get_chronicle_db_path(db_path_override: Option<&PathBuf>) -> std::io::Result<PathBuf> {
+    if let Some(path) = db_path_override {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        return Ok(path.clone());
+    }
     let chronicle_dir = get_chronicle_dir()?;
     Ok(chronicle_dir.join("chronicle.db"))
 }


### PR DESCRIPTION
Introduce a global `--db` argument to allow users to specify the path to the chronicle database file. Update relevant functions to utilize this new argument, enabling flexible database path management.